### PR TITLE
fix: tslib version

### DIFF
--- a/packages/nx-pm2-plugin/package.json
+++ b/packages/nx-pm2-plugin/package.json
@@ -6,6 +6,9 @@
   "peerDependencies": {
     "nx": "^16.0.0"
   },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
   "keywords": ["nx", "pm2", "plugin", "monorepo", "executors","custom-executors"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
By default, `nx` adds `tslib` to the package.json ([link](https://github.com/nrwl/nx/issues/9343)), but it tightly bound to a specific version, you can check here https://www.npmjs.com/package/nx-pm2-plugin?activeTab=code

Perhaps there are other ways to fix this.